### PR TITLE
Allow config to be packaged or fetched from URLs with basic auth

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,13 @@ Changelog for yay
 0.0.51 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Introduce a lazily evaluated mechanism for expanding the search path::
+
+      .search:
+        - package://some.egg/
+        - http://raw.github.com/isotoma/yay/
+
+  Any subsequent ``.import`` statements will be use the modified search path.
 
 
 0.0.50 (2012-07-10)

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Changelog for yay
 - If a package specified either as part of a .include or as part of a .search
   is not available on sys.path then an attempt will be made to install it.
 
+- Can pass config to opener backends using ``.config``
+
 
 0.0.50 (2012-07-10)
 -------------------

--- a/CHANGES
+++ b/CHANGES
@@ -15,7 +15,20 @@ Changelog for yay
 - If a package specified either as part of a .include or as part of a .search
   is not available on sys.path then an attempt will be made to install it.
 
-- Can pass config to opener backends using ``.config``
+- Can pass config to opener backends using ``.config``. For example, you might
+  want to have the ``package://`` opener to use your internal package
+  repository::
+
+      .config:
+          openers:
+              packages:
+                  index: https://my-python-mirror/simple/
+                  username: joe
+                  password: penguin55
+
+  You can use variable subsitution and to define the password in a GPG
+  encrypted yay file or to push the variable from application that is using
+  Yay.
 
 
 0.0.50 (2012-07-10)

--- a/CHANGES
+++ b/CHANGES
@@ -10,7 +10,7 @@ Changelog for yay
         - package://some.egg/
         - http://raw.github.com/isotoma/yay/
 
-  Any subsequent ``.import`` statements will be use the modified search path.
+  Any subsequent ``.import`` statements will use the modified search path.
 
 - If a package specified either as part of a .include or as part of a .search
   is not available on sys.path then an attempt will be made to install it.
@@ -38,6 +38,9 @@ Changelog for yay
 
       .search:
         - https://username:${password}@svn.yourcompany.org/svn/cookbook/trunk
+
+- ``.include`` and ``.search`` may be a single scalar value rather than a list
+  if you desire.
 
 
 0.0.50 (2012-07-10)

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,9 @@ Changelog for yay
 
   Any subsequent ``.import`` statements will be use the modified search path.
 
+- If a package specified either as part of a .include or as part of a .search
+  is not available on sys.path then an attempt will be made to install it.
+
 
 0.0.50 (2012-07-10)
 -------------------

--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,15 @@ Changelog for yay
   encrypted yay file or to push the variable from application that is using
   Yay.
 
+- Yay openers support basic auth in the url. If used with .include then use of
+  secrets to concatenate to hide the password is suggsted::
+
+      # Define ${password} in a GPG armored file
+      .include: home://.credentials.yay.gpg
+
+      .search:
+        - https://username:${password}@svn.yourcompany.org/svn/cookbook/trunk
+
 
 0.0.50 (2012-07-10)
 -------------------

--- a/yay/composer.py
+++ b/yay/composer.py
@@ -188,7 +188,7 @@ class Composer(object):
         key = key_event.value
 
         action = "assign"
-        if "." in key and key not in ('.include', '.search'):
+        if "." in key and key not in ('.include', '.search', '.config'):
             key, action = key.split(".", 1)
 
         action_args = None
@@ -256,6 +256,11 @@ class Composer(object):
                     previous = self.handle_imports(previous, includes)
 
                 previous = Mapping(previous)
+
+            elif key == ".config":
+                value.lock()
+                mapping = value.resolve()
+                self.openers.config.update(mapping.get("openers", {}))
 
             elif key == ".search":
                 self.openers.searchpath.extend(value.resolve())

--- a/yay/composer.py
+++ b/yay/composer.py
@@ -249,9 +249,8 @@ class Composer(object):
                 else:
                     value.lock()
                     includes = value.resolve()
-
                     if not isinstance(includes, list):
-                        value.error("Expected something that resolved to a sequence and didnt")
+                        includes = [includes]
 
                     previous = self.handle_imports(previous, includes)
 
@@ -263,7 +262,10 @@ class Composer(object):
                 self.openers.config.update(mapping.get("openers", {}))
 
             elif key == ".search":
-                self.openers.searchpath.extend(value.resolve())
+                searchpath = value.resolve()
+                if not isinstance(searchpath, list):
+                    searchpath = [searchpath]
+                self.openers.searchpath.extend(searchpath)
 
             elif key == ".define":
                 self.parent.definitions[value.defined_name] = value

--- a/yay/composer.py
+++ b/yay/composer.py
@@ -188,7 +188,7 @@ class Composer(object):
         key = key_event.value
 
         action = "assign"
-        if "." in key and key != '.include':
+        if "." in key and key not in ('.include', '.search'):
             key, action = key.split(".", 1)
 
         action_args = None
@@ -256,6 +256,9 @@ class Composer(object):
                     previous = self.handle_imports(previous, includes)
 
                 previous = Mapping(previous)
+
+            elif key == ".search":
+                self.openers.searchpath.extend(value.resolve())
 
             elif key == ".define":
                 self.parent.definitions[value.defined_name] = value

--- a/yay/nodes/mapping.py
+++ b/yay/nodes/mapping.py
@@ -59,9 +59,10 @@ class Mapping(Node):
         return data
 
     def walk(self):
-        for itm in self.value.items():
+        for itm in self.value.values():
             yield itm
-        yield self.predecessor
+        if self.predecessor:
+            yield self.predecessor
 
     def clone(self):
         p = None

--- a/yay/openers/__init__.py
+++ b/yay/openers/__init__.py
@@ -1,0 +1,4 @@
+
+from .base import *
+from .package import PackageOpener
+

--- a/yay/openers/base.py
+++ b/yay/openers/base.py
@@ -201,7 +201,7 @@ class Openers(object):
 
     def __init__(self, searchpath=None, config=None):
         self.searchpath = searchpath or []
-        self.config = {}
+        self.config = config
 
         self.openers = []
         for cls in IOpener.__subclasses__():

--- a/yay/openers/base.py
+++ b/yay/openers/base.py
@@ -19,6 +19,7 @@ import os
 import sys
 import subprocess
 import hashlib
+import base64
 
 from yay.errors import NotFound, NotModified
 
@@ -103,7 +104,18 @@ class UrlOpener(IOpener):
     schemes = ("http://", "https://")
 
     def open(self, uri, etag=None):
+        p = urlparse.urlparse(uri)
+        netloc = p.hostname
+        if p.port:
+            netloc += ":" + p.port
+        uri = urlparse.urlunparse((p.scheme, netloc, p[2], p[3], p[4], p[5]))
+
         req = urllib2.Request(uri)
+
+        if p.username and p.password:
+            header = base64.encodestring("%s:%s" % (p.username, p.password))
+            req.add_header("Authorization", "Basic " + header)
+
         if etag:
             req.add_header("If-None-Match", etag)
 

--- a/yay/openers/base.py
+++ b/yay/openers/base.py
@@ -213,7 +213,7 @@ class Openers(object):
 
     def __init__(self, searchpath=None, config=None):
         self.searchpath = searchpath or []
-        self.config = config
+        self.config = config or {}
 
         self.openers = []
         for cls in IOpener.__subclasses__():

--- a/yay/openers/base.py
+++ b/yay/openers/base.py
@@ -77,22 +77,6 @@ class FileOpener(IOpener):
         return f
 
 
-class PackageOpener(IOpener):
-
-    schemes = ("package://", )
-
-    def open(self, uri, etag=None):
-        package, uri = uri.lstrip("package://").split("/", 1)
-        try:
-            __import__(package)
-            module = sys.modules[package]
-        except ImportError:
-            raise NotFound("Package '%s' could not be imported")
-        module_path = os.path.dirname(module.__file__)
-        path = os.path.join(module_path, uri)
-        return FileOpener().open(path, etag)
-
-
 class HomeOpener(IOpener):
 
     schemes = ("home://", )

--- a/yay/openers/package.py
+++ b/yay/openers/package.py
@@ -104,16 +104,12 @@ class PackageOpener(IOpener):
             with TemporaryDirectory(dir=eggdir) as path:
                 download = self.index.download(matches[0].location, path)
 
-                # The base easy_install command
                 command = [sys.executable, "-c", self.cmd, '-ZmqNxd', eggdir]
-
-                # Actually add requirements
                 command.append(download)
+                p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                p.communicate()
 
-                # Actually run the command
-                result = subprocess.Popen(command).wait()
-
-                if result != 0:
+                if p.returncode != 0:
                     raise ImportError("Unable to automatically fetch package '%s'" % req)
 
         parsed = list(pkg_resources.parse_requirements(requirement))

--- a/yay/openers/package.py
+++ b/yay/openers/package.py
@@ -23,11 +23,10 @@ from .base import IOpener, FileOpener
 
 class PackageOpener(IOpener):
 
+    name = "packages"
     schemes = ("package://", )
 
     cmd = 'from setuptools.command.easy_install import main; main()'
-    python = sys.executable
-    eggdir = os.path.expanduser("~/.yay/packages")
 
     def open(self, uri, etag=None):
         package, uri = uri.lstrip("package://").split("/", 1)
@@ -47,15 +46,17 @@ class PackageOpener(IOpener):
         return FileOpener().open(path, etag)
 
     def _install(self, requirement):
+        eggdir = self.get_setting("cachedir", "~/.yay/packages")
+
         ws  = pkg_resources.working_set
-        ws.add_entry(self.eggdir)
+        ws.add_entry(eggdir)
 
         def _installer(requirement):
-            if not os.path.exists(self.eggdir):
-                os.makedirs(self.eggdir)
+            if not os.path.exists(eggdir):
+                os.makedirs(eggdir)
         
             # The base easy_install command
-            command = [self.python, "-c", self.cmd, '-mqNxd', self.eggdir]
+            command = [sys.executable, "-c", self.cmd, '-mqNxd', eggdir]
 
             # User can set up an alternative PyPI index
             # if self.index:

--- a/yay/openers/package.py
+++ b/yay/openers/package.py
@@ -35,8 +35,8 @@ class PackageOpener(IOpener):
             location = [self._install(package)]
             location.extend(package.split("."))
         except ImportError:
-	    # This old code path only exists for the old case where you might
-	    # have specified a module within a package to import
+            # This old code path only exists for the old case where you might
+            # have specified a module within a package to import
             try:
                 __import__(package)
                 module = sys.modules[package]

--- a/yay/openers/package.py
+++ b/yay/openers/package.py
@@ -1,0 +1,82 @@
+# Copyright 2010-2011 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import subprocess
+import pkg_resources
+from itertools import chain
+
+from yay.errors import NotFound
+from .base import IOpener, FileOpener
+
+class PackageOpener(IOpener):
+
+    schemes = ("package://", )
+
+    cmd = 'from setuptools.command.easy_install import main; main()'
+    python = sys.executable
+    eggdir = os.path.expanduser("~/.yay/packages")
+
+    def open(self, uri, etag=None):
+        package, uri = uri.lstrip("package://").split("/", 1)
+        try:
+            location = [self._install(package)]
+            location.extend(package.split("."))
+        except ImportError:
+	    # This old code path only exists for the old case where you might
+	    # have specified a module within a package to import
+            try:
+                __import__(package)
+                module = sys.modules[package]
+            except ImportError:
+                raise NotFound("Package '%s' could not be imported" % package)
+            location = [os.path.dirname(module.__file__)]
+        path = os.path.join(*chain(location, [uri]))
+        return FileOpener().open(path, etag)
+
+    def _install(self, requirement):
+        ws  = pkg_resources.working_set
+        ws.add_entry(self.eggdir)
+
+        def _installer(requirement):
+            if not os.path.exists(self.eggdir):
+                os.makedirs(self.eggdir)
+        
+            # The base easy_install command
+            command = [self.python, "-c", self.cmd, '-mqNxd', self.eggdir]
+
+            # User can set up an alternative PyPI index
+            # if self.index:
+            #     command.extend(["-i", self.index])
+
+            # Actually add requirements
+            command.append(str(requirement))
+
+            # Actually run the command
+            result = subprocess.Popen(command).wait()
+
+            if result != 0:
+                raise ImportError("Unable to automatically fetch package '%s' % requirement")
+
+            # Recursively resolve any dependencies of this package
+            ws.resolve([requirement], installer=_installer)
+            return pkg_resources.get_distribution(requirement)
+
+        parsed = list(pkg_resources.parse_requirements(requirement))
+        ws.resolve(parsed, installer=_installer)
+
+        distro = pkg_resources.get_distribution(requirement)
+        return distro.location
+

--- a/yay/tests/dogfood/config.in
+++ b/yay/tests/dogfood/config.in
@@ -1,0 +1,12 @@
+
+.config:
+    openers:
+        packages:
+            index: http://b.pypi.python.org/simple
+        memory:
+            example:
+                hello: world
+
+.include:
+  - mem://example
+

--- a/yay/tests/dogfood/config.out
+++ b/yay/tests/dogfood/config.out
@@ -1,0 +1,2 @@
+hello: world
+

--- a/yay/tests/dogfood/search.in
+++ b/yay/tests/dogfood/search.in
@@ -1,0 +1,9 @@
+
+.search:
+  - package://yay/tests/dogfood/search1
+  - package://yay/tests/dogfood/search2
+
+.include:
+  - somefile.yay
+  - onlyin2.yay
+

--- a/yay/tests/dogfood/search.out
+++ b/yay/tests/dogfood/search.out
@@ -1,0 +1,4 @@
+
+hello: this one
+goodbye: i dont know why
+

--- a/yay/tests/dogfood/search1/somefile.yay
+++ b/yay/tests/dogfood/search1/somefile.yay
@@ -1,0 +1,3 @@
+
+hello: this one
+

--- a/yay/tests/dogfood/search2/onlyin2.yay
+++ b/yay/tests/dogfood/search2/onlyin2.yay
@@ -1,0 +1,3 @@
+
+goodbye: i dont know why
+

--- a/yay/tests/dogfood/search2/somefile.yay
+++ b/yay/tests/dogfood/search2/somefile.yay
@@ -1,0 +1,3 @@
+
+hello: not this one
+

--- a/yay/tests/test_openers.py
+++ b/yay/tests/test_openers.py
@@ -57,18 +57,18 @@ class TestMemOpener(unittest.TestCase):
 
     def test_read(self):
         MemOpener.data['hello'] = "test data"
-        self.failUnlessEqual("test data", MemOpener().open("hello").read())
+        self.failUnlessEqual("test data", MemOpener().open("mem://hello").read())
 
     def test_notfound(self):
-        self.failUnlessRaises(NotFound, MemOpener().open, "does-not-exist")
+        self.failUnlessRaises(NotFound, MemOpener().open, "mem://does-not-exist")
 
     def test_etag(self):
         MemOpener.data['hello'] = "test data"
         mo = MemOpener()
-        fp = mo.open("hello")
+        fp = mo.open("mem://hello")
         etag = fp.etag
         fp.close()
 
-        self.failUnlessRaises(NotModified, mo.open, "hello", etag)
+        self.failUnlessRaises(NotModified, mo.open, "mem://hello", etag)
 
 


### PR DESCRIPTION
- Introduce a lazily evaluated mechanism for expanding the search path::
  
  ``` yaml
    .search:
      - package://some.egg/
      - http://raw.github.com/isotoma/yay/
  ```
  
  Any subsequent `.import` statements will use the modified search path.
- If a package specified either as part of a .include or as part of a .search
  is not available on sys.path then an attempt will be made to install it.
- Can pass config to opener backends using `.config`. For example, you might
  want to have the `package://` opener to use your internal package
  repository::
  
  ``````
  ```yaml
  .config:
      openers:
          packages:
              index: https://my-python-mirror/simple/
              username: joe
              password: penguin55
  ```
  ``````
  
  You can use variable subsitution and to define the password in a GPG
  encrypted yay file or to push the variable from application that is using
  Yay.
- Yay openers support basic auth in the url. If used with .include then use of
  secrets to concatenate to hide the password is suggsted::
  
  ``````
  ```yaml
  # Define ${password} in a GPG armored file
  .include: home://.credentials.yay.gpg
  
  .search:
    - https://username:${password}@svn.yourcompany.org/svn/cookbook/trunk
  ```
  ``````
- `.include` and `.search` may be a single scalar value rather than a list
  if you desire.
