### PR TITLE
GPG error handling improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Changelog for yay
   but means you now *MUST* use a GPG agent as it can no longer prompt for a
   passphrase.
 
+- GPG_TTY is set - this means gpg-agent can actually prompt now.
+
 
 0.0.57 (2012-08-02)
 -------------------

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,12 @@ Changelog for yay
 0.0.58 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Capture GPG failures and throw exceptions. Unfortunately without talking to
+  GPG over the status fd we can't get much information about what went wrong.
+
+- Run in batch mode. This stops GPG from ignoring the stdout/stderr redirection
+  but means you now *MUST* use a GPG agent as it can no longer prompt for a
+  passphrase.
 
 
 0.0.57 (2012-08-02)

--- a/yay/openers/base.py
+++ b/yay/openers/base.py
@@ -200,8 +200,10 @@ class Gpg(object):
 
     def filter(self, fp):
         data = fp.read()
-        p = subprocess.Popen(["gpg", "-d"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        p = subprocess.Popen(["gpg", "--batch", "-d"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
         stdout, stderr = p.communicate(data)
+        if p.returncode != 0:
+            raise NotFound("Unable to decrypt resource")
         stream = StringIO.StringIO(stdout)
         stream.etag = fp.etag
         stream.len = len(stdout)


### PR DESCRIPTION
This stops GPG spamming the console as it tries to decrypt secrets. It turns out that despite redirecting stdout and stderr, unless GPG is in batch mode it will still manage to spam the console.

Unfortunately --batch stops in prompting for a password. This was never really supported behaviour - but does mean that people will have to actually set up GPG now.

While in there I now actually check the exit code and throw a NotFound error if decryption failed. Some sort of analogue to a HTTP 500 would be preferable to NotFound but things already properly handle NotFound so that will do for now.
